### PR TITLE
enum && add nyc coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ jspm_packages
 #.idea
 /.idea
 /temp
+/.nyc_output

--- a/example/middleware/errorHandle.js
+++ b/example/middleware/errorHandle.js
@@ -2,7 +2,6 @@ export default () => async (ctx, next) => {
   try {
     await next();
   } catch (error) {
-    console.log(error.stack);
     ctx.status = error.status || 400;
     ctx.body = { msg: error.toString() };
   }

--- a/example/routes/sample.js
+++ b/example/routes/sample.js
@@ -38,13 +38,34 @@ export default class SampleRouter {
   })
   @responses({
     200:
-    { description: 'file upload success' },
+      { description: 'file upload success' },
     500:
-    { description: 'something wrong about server' }
+      { description: 'something wrong about server' }
   })
   static async upload(ctx) {
     const { file } = ctx.req;
     file.url = getFileUrl(file.filename);
     ctx.body = { result: file };
+  }
+
+  @request('get', '/enum')
+  @summary('example of  enum')
+  @description('example of  enum')
+  @tag
+  @middlewares([upload.single('file')])
+  @query({
+    page: {
+      type: 'string', enum: ['1', '2', '3'], description: 'page number'
+    }
+  })
+  @responses({
+    200:
+      { description: 'success' },
+    500:
+      { description: 'something wrong about server' }
+  })
+  static async enum(ctx) {
+    const { page } = ctx.request.query;
+    ctx.body = { result: page };
   }
 }

--- a/lib/validate/check.js
+++ b/lib/validate/check.js
@@ -26,6 +26,7 @@ const cString = (val, expect) => {
 
 const cNum = (val, expect) => {
   if (!cRequired(val, expect).is) return { is: false };
+  if (!cEnum(val, expect).is) return { is: false };
   return isNaN(Number(val)) ? { is: false } : { is: true, val: Number(val) };
 };
 

--- a/lib/validate/check.js
+++ b/lib/validate/check.js
@@ -8,11 +8,19 @@ const cRequired = (input, expect = {}) => {
   return { is: true, val: input };
 };
 
+const cEnum = (input, expect = {}) => {
+  if (Array.isArray(expect.enum) && expect.enum.length) {
+    return expect.enum.includes(input) ? ({ is: true, val: input }) : { is: false };
+  }
+  return { is: true, val: input };
+};
+
 const cDefault = (input, expect = {}) =>
   expect.default !== undefined && input === undefined ? { is: true, val: expect.default } : { is: true, val: input };
 
 const cString = (val, expect) => {
   if (!cRequired(val, expect).is) return { is: false };
+  if (!cEnum(val, expect).is) return { is: false };
   return typeof val === 'string' ? ({ is: true, val: String(val) }) : { is: false };
 };
 

--- a/lib/validate/check.js
+++ b/lib/validate/check.js
@@ -20,13 +20,13 @@ const cDefault = (input, expect = {}) =>
 
 const cString = (val, expect) => {
   if (!cRequired(val, expect).is) return { is: false };
-  if (!cEnum(val, expect).is) return { is: false };
+  if (expect.enum && !cEnum(val, expect).is) return { is: false };
   return typeof val === 'string' ? ({ is: true, val: String(val) }) : { is: false };
 };
 
 const cNum = (val, expect) => {
   if (!cRequired(val, expect).is) return { is: false };
-  if (!cEnum(val, expect).is) return { is: false };
+  if (expect.enum && !cEnum(Number(val), expect).is) return { is: false };
   return isNaN(Number(val)) ? { is: false } : { is: true, val: Number(val) };
 };
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lodash": "^4.17.4",
     "mocha": "^5.1.1",
     "nodemon": "^1.11.0",
+    "nyc": "^12.0.2",
     "power-assert": "^1.5.0",
     "sha1": "^1.1.1",
     "supertest": "^2.0.1",
@@ -39,7 +40,8 @@
     "start": "nodemon --watch example --exec npm run start:babel -L",
     "test": "./node_modules/mocha/bin/mocha --require babel-core/register test/**/*.js --bail -t 2000000",
     "prepublish": "npm run build",
-    "debug": "babel-node example/main --inspect --debug-brk --nolazy example/main"
+    "debug": "babel-node example/main --inspect --debug-brk --nolazy example/main",
+    "cov": "nyc --reporter=lcov npm run test"
   },
   "keywords": [
     "decorator",

--- a/test/test.js
+++ b/test/test.js
@@ -299,4 +299,37 @@ describe('Validate:', () => {
     input.arr = [{ url: 'a', other: 'b', num: '33' }, { url: 'a', name: 'b' }];
     validate(input, expect);
   });
+
+  it('throw error when enum is an empty array', () => {
+    const input = { foo: '1' };
+    const expect = {
+      foo: { type: 'string', enum: [] }
+    };
+    try {
+      validate(input, expect);
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+
+  it('throw error when enum doesnot include input', () => {
+    const input = { foo: '1' };
+    const expect = {
+      foo: { type: 'string', enum: ['2', '3', '4'] }
+    };
+    try {
+      validate(input, expect);
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+
+  it(' when enum doesnot include input', () => {
+    const input = { foo: '1' };
+    const expect = {
+      foo: { type: 'string', enum: ['1', '2', '3', '4'] }
+    };
+    const { foo } = validate(input, expect);
+    assert(foo === '1');
+  });
 });


### PR DESCRIPTION
Same enum feature commited in egg-swagger-decorator
[ egg-pr ] (https://github.com/Cody2333/egg-swagger-decorator/pull/1)

Add nyc to do coverage.
### in package.json
```
{
  script:{
     "nyc":"....."
 }
}
```
need to complete other test.