### PR TITLE
remove unnamed-parameters prefix `:`

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,7 +5,7 @@ import is from 'is-type-of';
 // eg. /api/{id} -> /api/:id
 const convertPath = (path: string) => {
   const re = new RegExp('{(.*?)}', 'g');
-  return path.replace(re, ':$1');
+  return path.replace(re, (m, k) => k.startsWith('(') ? k : `:${k}`);
 };
 
 const getPath = (prefix: string, path: string) =>


### PR DESCRIPTION
// convert path: `/api/{(.*)}` => `/api/(.*)`, see [koa-router path patterners](https://www.npmjs.com/package/path-to-regexp#unnamed-parameters)