### PR TITLE
fix: 修复typescript下static method不显示问题

### DIFF
--- a/lib/wrapper.ts
+++ b/lib/wrapper.ts
@@ -143,7 +143,11 @@ const handleMap = (
 
   const staticMethods = Object.getOwnPropertyNames(SwaggerClass)
     .filter(method => !reservedMethodNames.includes(method))
-    .map(method => SwaggerClass[method]);
+    .map((method) => {
+      const func = SwaggerClass[method];
+      func['fnName'] = method;
+      return func;
+    });
 
   const SwaggerClassPrototype = SwaggerClass.prototype;
   const methods = Object.getOwnPropertyNames(SwaggerClassPrototype)
@@ -172,12 +176,7 @@ const handleMap = (
     })
     // add router
     .forEach((item) => {
-      if (item.name === 'wrapperMethod') {
-        // 添加 swaggerKeys
-        router._addKey(`${SwaggerClass.name}-${item.fnName}`);
-      } else {
-        router._addKey(`${SwaggerClass.name}-${item.name}`);
-      }
+      router._addKey(`${SwaggerClass.name}-${item.fnName}`);
       const { path, method } = item as { path: string, method: string };
       let { middlewares = [] } = item;
       const localParams = item.parameters || {};


### PR DESCRIPTION
TypeScript 编译成ES5之后 类的方法引用的是一个匿名函数，function.name是一个空字符串，生成的key值与装饰器的key值不一致，会导致文档无法显示。改为统一使用fnName生成key。