### PR TITLE
Add string format validation

### DIFF
--- a/lib/validate/check.ts
+++ b/lib/validate/check.ts
@@ -1,4 +1,5 @@
 import is from 'is-type-of';
+import validator from 'validator';
 import _ from 'ramda';
 
 export interface Expect {
@@ -40,10 +41,22 @@ const cDefault = (input: any, expect: Expect = {}) =>
 const cString = (val: any, expect: Expect) => {
   if (!cRequired(val, expect).is) return { is: false };
   if (expect.enum && !cEnum(val, expect).is) return { is: false };
+  if (expect.format && !cFormat(val, expect).is) return { is: false };
   return typeof val === 'string'
     ? { is: true, val: String(val) }
     : { is: false };
 };
+
+const cFormat = (val: any, expect: Expect) => {
+  if (expect.format === 'email' && !validator.isEmail(val)) return { is: false };
+  if (expect.format === 'uuid' && !validator.isUUID(val)) return { is: false };
+  if ((expect.format === 'date' || expect.format === 'date-time') && !validator.isRFC3339(val)) return { is: false };
+  if (expect.format === 'byte' && !validator.isBase64(val)) return { is: false };
+  if (expect.format === 'ipv4' && !validator.isIP(val, 4)) return { is: false };
+  if (expect.format === 'ipv6' && !validator.isIP(val, 6)) return { is: false };
+  
+  return { is: true, val: String(val) };
+}
 
 const cNum = (val: any, expect: Expect) => {
   if (!cRequired(val, expect).is) return { is: false };

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "@types/globby": "^8.0.0",
     "@types/koa-router": "^7.0.31",
     "@types/ramda": "^0.25.36",
+    "@types/validator": "^13.1.0",
     "globby": "^8.0.1",
     "is-type-of": "^1.2.0",
     "koa-router": "^7.2.1",
-    "ramda": "^0.25.0"
+    "ramda": "^0.25.0",
+    "validator": "^13.1.17"
   },
   "nyc": {
     "include": [

--- a/test/test.js
+++ b/test/test.js
@@ -226,7 +226,14 @@ describe('Validate:', () => {
       addon: 'ttt',
       boo: 'true',
       coo: 'false',
-      sst: '666'
+      sst: '666',
+      uuid: '208d0175-23e8-46ca-9013-5164d74bc3c7',
+      email: 'test@test.com',
+      date: '2020-11-14T10:00:00Z',
+      "date-time": '2020-11-14T12:00:00Z',
+      byte: 'U3dhZ2dlciByb2Nrcw==',
+      ipv4: '127.0.0.1',
+      ipv6: '::1'
     };
     const expect = {
       nax: { type: 'number' },
@@ -264,6 +271,13 @@ describe('Validate:', () => {
       sst: {
         type: 'string'
       },
+      uuid: { type: 'string', format: 'uuid' },
+      email: { type: 'string', format: 'email' },
+      date: { type: 'string', format: 'date' },
+      "date-time": { type: 'string', format: 'date-time' },
+      byte: { type: 'string', format: 'byte' },
+      ipv4: { type: 'string', format: 'ipv4' },
+      ipv6: { type: 'string', format: 'ipv6' },
       addon: undefined
     };
     const validatedInput = validate(input, expect);
@@ -273,6 +287,13 @@ describe('Validate:', () => {
     assert(validatedInput.boo === true);
     assert(validatedInput.coo === false);
     assert(typeof validatedInput.sst === 'string');
+    assert(validatedInput.uuid === '208d0175-23e8-46ca-9013-5164d74bc3c7');
+    assert(validatedInput.email === 'test@test.com');
+    assert(validatedInput.date === '2020-11-14T10:00:00Z');
+    assert(validatedInput["date-time"] === '2020-11-14T12:00:00Z');
+    assert(validatedInput.byte === 'U3dhZ2dlciByb2Nrcw==');
+    assert(validatedInput.ipv4 === '127.0.0.1');
+    assert(validatedInput.ipv6 === '::1');
   });
   it('should throw error when no required input', () => {
     const input = {};
@@ -329,7 +350,76 @@ describe('Validate:', () => {
       assert(err.message === "incorrect field: 'foo', please check again!");
     }
   });
-
+  it('should throw error when using wrong format while type=string format=uuid', () => {
+    const input = { foo: 'bad-uuid' };
+    const expect = { foo: { type: 'string', format: 'uuid' } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when using wrong format while type=string format=email', () => {
+    const input = { foo: 'bad-email' };
+    const expect = { foo: { type: 'string', format: 'email' } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when using wrong format while type=string format=date', () => {
+    const input = { foo: '11-14-2017' };
+    const expect = { foo: { type: 'string', format: 'date' } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when using wrong format while type=string format=date-time', () => {
+    const input = { foo: '2017-07-21 17:32:28' };
+    const expect = { foo: { type: 'string', format: 'date' } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when using wrong format while type=string format=byte', () => {
+    const input = { foo: 'not a base 64 string' };
+    const expect = { foo: { type: 'string', format: 'byte' } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when using wrong format while type=string format=ipv4', () => {
+    const input = { foo: '::1' };
+    const expect = { foo: { type: 'string', format: 'ipv4' } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when using wrong format while type=string format=ipv6', () => {
+    const input = { foo: '127.0.0.1' };
+    const expect = { foo: { type: 'string', format: 'ipv6' } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
   it('shoud support complex object data', () => {
     const expect = {
       o1: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,6 +533,11 @@
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
+"@types/validator@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.1.0.tgz#3d776127dbce7dd31fc06f86d3428b072e631eba"
+  integrity sha512-gHUHI6pJaANIO2r6WcbT7+WMgbL9GZooR4tWpuBOETpDIqFNxwaJluE+6rj6VGYe8k6OkfhbHz2Fkm8kl06Igw==
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -7229,6 +7234,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^13.1.17:
+  version "13.1.17"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.1.17.tgz#ad677736950adddd3c37209484a6b2e0966579ad"
+  integrity sha512-zL5QBoemJ3jYFb2/j38y7ljhwYGXVLUp8H6W1nVxadnAOvUOytec+L7BHh1oBQ82/TzWXHd+GSaxUWp4lROkLg==
 
 vary@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
I needed string format validation for uuid 

So in this PR, I added some formats validation using [validator](https://www.npmjs.com/package/validator) based on [Swagger spec](https://swagger.io/docs/specification/data-models/data-types/#string) and updated the tests.

I saw https://github.com/Cody2333/koa-swagger-decorator/issues/60 where the target is to use [joi](https://www.npmjs.com/package/joi), but the issue is pretty old and I didn't see any branch where it's started.

As this PR doesn't break the existent and add a basic string format validation, could it be released before the rewriting of the validation ?