### PR TITLE
fix: #109 swagger json incorrectly structures 'required' on body schemas

### DIFF
--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -12,7 +12,7 @@ const _desc = (type: string, text: string | any[]) => (
   return descriptor;
 };
 
-const _stripInvalidStructureFieldsFromParams = (parameters: { [name: string]: any }) => {
+const _stripInvalidStructureFieldsFromBodyParams = (parameters: { [name: string]: any }) => {
   const keys = Object.keys(parameters);
   for (const key of keys) {
     delete parameters[key].required;
@@ -38,7 +38,7 @@ const _params = (type: string, parameters: { [name: string]: any }) => (
         schema: {
           type: 'object',
           required: Object.keys(parameters).filter(parameterName => parameters[parameterName].required),
-          properties: _stripInvalidStructureFieldsFromParams(parameters)
+          properties: _stripInvalidStructureFieldsFromBodyParams(parameters)
         }
       }
     ];

--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -12,6 +12,14 @@ const _desc = (type: string, text: string | any[]) => (
   return descriptor;
 };
 
+const _stripInvalidStructureFieldsFromParams = (parameters: { [name: string]: any }) => {
+  const keys = Object.keys(parameters);
+  for (const key of keys) {
+    delete parameters[key].required;
+  }
+  return parameters;
+};
+
 const _params = (type: string, parameters: { [name: string]: any }) => (
   target: any,
   name: string,
@@ -29,11 +37,8 @@ const _params = (type: string, parameters: { [name: string]: any }) => (
         description: 'request body',
         schema: {
           type: 'object',
-          required: Object.keys(parameters || {}).filter(parameterName => parameters[parameterName].required),
-          properties: (parameters || []).map((parameter: any) => {
-            delete parameter.required;
-            return parameter;
-          })
+          required: Object.keys(parameters).filter(parameterName => parameters[parameterName].required),
+          properties: _stripInvalidStructureFieldsFromParams(parameters)
         }
       }
     ];

--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -42,6 +42,9 @@ const _params = (type: string, parameters: { [name: string]: any }) => (
         }
       }
     ];
+    if (swaggerParameters[0].schema.required.length === 0) {
+      delete swaggerParameters[0].schema.required;
+    }
   } else {
     swaggerParameters = Object.keys(swaggerParameters).map(key =>
       Object.assign({ name: key }, swaggerParameters[key]));

--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -29,7 +29,11 @@ const _params = (type: string, parameters: { [name: string]: any }) => (
         description: 'request body',
         schema: {
           type: 'object',
-          properties: parameters
+          required: Object.keys(parameters).filter(parameterName => parameters[parameterName].required),
+          properties: parameters.map((parameter: any) => {
+            delete parameter.required;
+            return parameter;
+          })
         }
       }
     ];

--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -29,8 +29,8 @@ const _params = (type: string, parameters: { [name: string]: any }) => (
         description: 'request body',
         schema: {
           type: 'object',
-          required: Object.keys(parameters).filter(parameterName => parameters[parameterName].required),
-          properties: parameters.map((parameter: any) => {
+          required: Object.keys(parameters || {}).filter(parameterName => parameters[parameterName].required),
+          properties: (parameters || []).map((parameter: any) => {
             delete parameter.required;
             return parameter;
           })


### PR DESCRIPTION
For some reason Swagger expects the required fields to be listed for a body object, rather than inlined under each body parameter.

Closes #109 