### PR TITLE
if the option value is null or an object

### DIFF
--- a/lib/swaggerHTML.ts
+++ b/lib/swaggerHTML.ts
@@ -1,11 +1,17 @@
 function parseSimpleConfig(config: {[name: string]: any} = {}) {
     return Object.keys(config).map(key => {
         const value: any = config[key];
+        if(value === null) {
+            return `${key}: null,`;
+        }
         if (typeof value === 'string') {
             return `${key}: '${value}',`;
         }
         if (typeof value === 'number' || typeof value === 'boolean') {
             return `${key}: ${value},`;
+        }
+        if (typeof value === 'object') {
+          return `${key}: ${JSON.stringify(value)},`
         }
     }).join('\n\t  ');
 }


### PR DESCRIPTION
We want to disable the validator badge, so we tried to add option `validatorUrl: null` to swagger-ui `swaggerConfiguration`

```javascript
const swaggerRouter = new SwaggerRouter();
swaggerRouter.swagger({
    ...
    //swagger ui config https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
    swaggerConfiguration: {
        display: {
            validatorUrl: null
        }
    }
});
```

But, this did not works, and we tried a few fixes by change the file `./dist/swaggerHTML.js`, and it works