### PR TITLE
Allow functions within the parseSimpleConfig

### DIFF
--- a/lib/swaggerHTML.ts
+++ b/lib/swaggerHTML.ts
@@ -7,7 +7,7 @@ function parseSimpleConfig(config: {[name: string]: any} = {}) {
         if (typeof value === 'string') {
             return `${key}: '${value}',`;
         }
-        if (typeof value === 'number' || typeof value === 'boolean') {
+        if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'function') {
             return `${key}: ${value},`;
         }
         if (typeof value === 'object') {


### PR DESCRIPTION
This allows hooks into the onComplete function which could facilitate other methods such as ui.initOAuth()
By allowing functions you can add additional properties to the display config and access them like so:

```js
swaggerConfiguration: {
  oauth2ClientId: config.clientId,
  oauth2ClientSecret: config.clientSecret,
  onComplete: function() {
    const { oauth2ClientId, oauth2ClientSecret } = ui.getConfigs();
    ui.initOAuth({
      clientId: oauth2ClientId,
      clientSecret: oauth2ClientSecret,
    });
  }
}
```