### PR TITLE
Allow passing $ref as body parameters

### DIFF
--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -32,19 +32,31 @@ const _params = (type: string, parameters: { [name: string]: any }) => (
   // additional wrapper for body
   let swaggerParameters = parameters;
   if (type === 'body') {
-    swaggerParameters = [
-      {
-        name: 'data',
-        description: 'request body',
-        schema: {
-          type: 'object',
-          required: Object.keys(parameters).filter(parameterName => parameters[parameterName].required),
-          properties: _stripInvalidStructureFieldsFromBodyParams(parameters)
+    if (parameters.$ref) {
+      swaggerParameters = [
+        {
+          name: 'data',
+          description: 'request body',
+          schema: {
+            $ref: parameters.$ref
+          }
         }
+      ];
+    } else {
+      swaggerParameters = [
+        {
+          name: 'data',
+          description: 'request body',
+          schema: {
+            type: 'object',
+            required: Object.keys(parameters).filter(parameterName => parameters[parameterName].required),
+            properties: _stripInvalidStructureFieldsFromBodyParams(parameters)
+          }
+        }
+      ];
+      if (swaggerParameters[0].schema.required.length === 0) {
+        delete swaggerParameters[0].schema.required;
       }
-    ];
-    if (swaggerParameters[0].schema.required.length === 0) {
-      delete swaggerParameters[0].schema.required;
     }
   } else {
     swaggerParameters = Object.keys(swaggerParameters).map(key =>


### PR DESCRIPTION
With this change it would be possible for the body decorator to make reference to already existing models within the definitions key of the swagger-json. This prevents duplication of generated schemas.

Usage example:
`@body({ $ref: '#/definitions/Order' })`

You can see this method used in the Swagger Petstore example:
[https://petstore.swagger.io/v2/swagger.json](url)
![image](https://user-images.githubusercontent.com/4449468/157751685-fbd22d07-4bb3-4450-a254-d0fd5c5739b1.png)
