### PR TITLE
feature: add missing string/number validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install
 npm run start
 
 finally open:
-http://localhost:3000/api/swagger-html
+http://localhost:3000/api/v2/swagger-html
 ```
 
 ### Requirements

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -234,14 +234,22 @@ describe('Validate:', () => {
       ipv6: '::1'
     };
     const expect: any = {
-      nax: { type: 'number' },
+      nax: {
+        type: 'number',
+        exclusiveMinimum: 11,
+        exclusiveMaximum: 13,
+        multipleOf: 4
+      },
       foo: {
         type: 'number',
         required: true
       },
       bar: {
         type: 'string',
-        required: false
+        required: false,
+        minLength: 1,
+        maxLength: 3,
+        pattern: '^[qwf]{3,}$'
       },
       baz: {
         type: 'object',
@@ -328,7 +336,7 @@ describe('Validate:', () => {
       assert(err.message === "incorrect field: 'foo', please check again!");
     }
   });
-  it('should throw error when not a number while type=object', () => {
+  it('should throw error when not an object while type=object', () => {
     const input = { foo: 'r' };
     const expect = { foo: { type: 'object' } };
     try {
@@ -338,7 +346,7 @@ describe('Validate:', () => {
       assert(err.message === "incorrect field: 'foo', please check again!");
     }
   });
-  it('should throw error when not a number while type=array', () => {
+  it('should throw error when not an array while type=array', () => {
     const input = { foo: 'r' };
     const expect = { foo: { type: 'array' } };
     try {
@@ -411,6 +419,67 @@ describe('Validate:', () => {
   it('should throw error when using wrong format while type=string format=ipv6', () => {
     const input = { foo: '127.0.0.1' };
     const expect = { foo: { type: 'string', format: 'ipv6' } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when minLength not satisfied for type=string', () => {
+    const input = { foo: 'asdf' };
+    const expect = { foo: { type: 'string', minLength: 10 } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when maxLength not satisfied for type=string', () => {
+    const input = { foo: 'foobarbaz' };
+    const expect = { foo: { type: 'string', maxLength: 5 } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when pattern not satisfied for type=string', () => {
+    const input = { foo: 'foobarbaz' };
+    const expect = { foo: { type: 'string', pattern: '^[0-9]+$' } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+
+  it('should throw error when exclusiveMinimum not satisfied for type=number', () => {
+    const input = { foo: 5 };
+    const expect = { foo: { type: 'number', exclusiveMinimum: 5 } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when exclusiveMaximum not satisfied for type=number', () => {
+    const input = { foo: 5 };
+    const expect = { foo: { type: 'number', exclusiveMaximum: 5 } };
+    try {
+      validate(input, expect);
+      throw new Error();
+    } catch (err) {
+      assert(err.message === "incorrect field: 'foo', please check again!");
+    }
+  });
+  it('should throw error when multipleOf not satisfied for type=number', () => {
+    const input = { foo: 5 };
+    const expect = { foo: { type: 'number', multipleOf: 3 } };
     try {
       validate(input, expect);
       throw new Error();

--- a/example/routes/v2/egg.ts
+++ b/example/routes/v2/egg.ts
@@ -23,7 +23,10 @@ export default class EggRouter {
       type: 'string',
       require: true,
       description: 'yesyesyes',
-      nullable: true
+      nullable: true,
+      minLength: 2,
+      maxLength: 10,
+      pattern: '^[0-9]+$'
     }
   })
   async method2(ctx) {

--- a/example/routes/v2/sub_routes/sub1.ts
+++ b/example/routes/v2/sub_routes/sub1.ts
@@ -26,7 +26,14 @@ export default class OtherRouter {
   @body({
     str: { type: 'string' },
     boo: { type: 'boolean' },
-    nn: { type: 'number' },
+    nn: {
+      type: 'number',
+      minimum: 0,
+      maximum: 7,
+      exclusiveMinimum: -1,
+      exclusiveMaximum: 8,
+      multipleOf: 2
+    },
     foo: {
       type: 'array',
       required: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@commitlint/cli': ^8.3.6
@@ -74,8 +74,8 @@ devDependencies:
   power-assert: 1.6.1
   standard-version: 9.3.2
   supertest: 2.0.1
-  ts-jest: 26.5.6_jest@26.6.3+typescript@4.5.4
-  ts-node: 10.4.0_00264fd83560919cd06c986889baae0a
+  ts-jest: 26.5.6_hoj6rh37du6uxub6buv3fchqgy
+  ts-node: 10.4.0_aate7wbvmcizzudmtbuitovobi
   typescript: 4.5.4
 
 packages:
@@ -240,6 +240,8 @@ packages:
     resolution: {integrity: sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.16.0
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.16.5:
@@ -958,6 +960,12 @@ packages:
   /@types/keygrip/1.0.2:
     resolution: {integrity: sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==}
 
+  /@types/keyv/3.1.4:
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+    dependencies:
+      '@types/node': 16.11.17
+    dev: true
+
   /@types/koa-bodyparser/5.0.2:
     resolution: {integrity: sha512-prJC/gtxnurTTOpYkSwMwzbkiZ6BCW7arIvjmNVbEziauhcndQeCewzsSphmtlI6wnwFnGGAAOznQR1OYrhhgw==}
     dependencies:
@@ -1033,6 +1041,12 @@ packages:
 
   /@types/range-parser/1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
+
+  /@types/responselike/1.0.0:
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
+    dependencies:
+      '@types/node': 16.11.17
+    dev: true
 
   /@types/serve-static/1.13.10:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
@@ -1174,6 +1188,8 @@ packages:
     dependencies:
       micromatch: 3.1.10
       normalize-path: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /anymatch/3.1.2:
@@ -1409,6 +1425,8 @@ packages:
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /braces/3.0.2:
@@ -1956,8 +1974,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -2107,14 +2125,36 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
+
+  /debug/3.2.7_supports-color@5.5.0:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+      supports-color: 5.5.0
     dev: true
 
   /debug/4.3.3:
@@ -2471,6 +2511,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /expect/26.6.2:
@@ -2516,6 +2558,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /fast-glob/3.2.7:
@@ -2658,7 +2702,7 @@ packages:
     dev: true
 
   /fsevents/2.3.2:
-    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=}
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -2819,6 +2863,8 @@ packages:
     dependencies:
       '@sindresorhus/is': 0.14.0
       '@szmarczak/http-timer': 1.1.2
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
@@ -3485,7 +3531,7 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.4
       pretty-format: 26.6.2
-      ts-node: 10.4.0_00264fd83560919cd06c986889baae0a
+      ts-node: 10.4.0_aate7wbvmcizzudmtbuitovobi
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -3575,6 +3621,8 @@ packages:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /jest-jasmine2/26.6.3_ts-node@10.4.0:
@@ -3672,6 +3720,8 @@ packages:
       '@jest/types': 26.6.2
       jest-regex-util: 26.0.0
       jest-snapshot: 26.6.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /jest-resolve/26.6.2:
@@ -3788,6 +3838,8 @@ packages:
       natural-compare: 1.4.0
       pretty-format: 26.6.2
       semver: 7.3.5
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /jest-util/26.6.2:
@@ -4008,6 +4060,8 @@ packages:
       http-errors: 1.8.1
       mz: 2.7.0
       resolve-path: 1.4.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /koa-static/4.0.3:
@@ -4016,6 +4070,8 @@ packages:
     dependencies:
       debug: 3.2.7
       koa-send: 4.1.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /koa/2.13.4:
@@ -4262,6 +4318,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /micromatch/4.0.4:
@@ -4400,6 +4458,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /natural-compare/1.4.0:
@@ -4446,7 +4506,7 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 3.5.2
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@5.5.0
       ignore-by-default: 1.0.1
       minimatch: 3.0.4
       pstree.remy: 1.1.8
@@ -5273,6 +5333,8 @@ packages:
       micromatch: 3.1.10
       minimist: 1.2.5
       walker: 1.0.8
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /saxes/5.0.1:
@@ -5413,6 +5475,8 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /source-map-resolve/0.5.3:
@@ -5640,6 +5704,8 @@ packages:
       mime: 1.6.0
       qs: 6.10.2
       readable-stream: 2.3.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /supertest/2.0.1:
@@ -5648,6 +5714,8 @@ packages:
     dependencies:
       methods: 1.1.2
       superagent: 2.3.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /supports-color/5.5.0:
@@ -5817,7 +5885,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-jest/26.5.6_jest@26.6.3+typescript@4.5.4:
+  /ts-jest/26.5.6_hoj6rh37du6uxub6buv3fchqgy:
     resolution: {integrity: sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==}
     engines: {node: '>= 10'}
     hasBin: true
@@ -5839,7 +5907,7 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-node/10.4.0_00264fd83560919cd06c986889baae0a:
+  /ts-node/10.4.0_aate7wbvmcizzudmtbuitovobi:
     resolution: {integrity: sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
- String validation checks added: minLength, maxLength, pattern
- Number validation checks added: exclusiveMinimum, exclusiveMaximum, multipleOf
- Added tests
- Updated the examples to include one of each of the above settings
- Other:
  - Fixed the README link for running examples (let me know if it should include v1 too?)
  - Updated the Expect type in check.ts to include some other missing properties
  - The pnpm lockfile got updated, I am using pnpm@7, but it looks like it updated the lockfileVersion

Let me know on anything you want me to revert!